### PR TITLE
Convert the VPC Flow Logs attributes to Int

### DIFF
--- a/index.js
+++ b/index.js
@@ -223,14 +223,21 @@ exports.handler = function (event, context) {
   recordStream._transform = function (line, encoding, done) {
     var logRecord = parser(line.toString());
     // In case of VPC Flow Logs
-    if (logType === "vpc" && logRecord.start_utc !== "Invalid date") {
-      /*
+    if (logType === "vpc") {
+      for (let key in logRecord) {
+        if (typeof logRecord[key] === "string" && !isNaN(logRecord[key])) {
+          logRecord[key] = parseInt(logRecord[key], 10);
+        }
+      }
+      if (logRecord.start_utc !== "Invalid date") {
+        /*
       We want to add the 'timestamp' field using 'start_utc' value
       as VPC Flow Logs don't log a timestamp. We need this otherwise
       OpenSearch will not be able to parse the timestamp field.
       */
-      let startDateTime = new Date(logRecord.start_utc);
-      logRecord.timestamp = startDateTime.toISOString();
+        let startDateTime = new Date(logRecord.start_utc);
+        logRecord.timestamp = startDateTime.toISOString();
+      }
     }
     let dstPort = parseInt(logRecord.dstport);
     if (


### PR DESCRIPTION
Fix #4 

Before:

```json
{
  version: '2',
  account_id: '11111',
  interface_id: 'eni-901258d8',
  srcaddr: '133.130.120.204',
  dstaddr: '172.31.23.15',
  srcport: '123',
  dstport: '123',
  protocol: '17',
  packets: '3',
  byte: '228',
  start: '1460005175',
  end: '1460005449',
  action: 'ACCEPT',
  log_status: 'OK',
  protocol_name: 'UDP',
  start_utc: '2016-04-07 04:59:35',
  end_utc: '2016-04-07 05:04:09'
}
```

After:

```json
{
  version: 2,
  account_id: 11111,
  interface_id: 'eni-901258d8',
  srcaddr: '133.130.120.204',
  dstaddr: '172.31.23.15',
  srcport: 123,
  dstport: 123,
  protocol: 17,
  packets: 3,
  byte: 228,
  start: 1460005175,
  end: 1460005449,
  action: 'ACCEPT',
  log_status: 'OK',
  protocol_name: 'UDP',
  start_utc: '2016-04-07 04:59:35',
  end_utc: '2016-04-07 05:04:09'
}
```