### PR TITLE
Correct req path, add request_creation_time field to vpcflowlogs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release
 
-on:  [ push ]
+on: 
+  push:
+    tags:
+      - '*'
 
 jobs:
   release:

--- a/index.js
+++ b/index.js
@@ -244,6 +244,7 @@ exports.handler = function (event, context) {
       */
         let startDateTime = new Date(logRecord.start_utc);
         logRecord.timestamp = startDateTime.toISOString();
+        logRecord.request_creation_time = startDateTime.toISOString();
       }
     }
     let dstPort = parseInt(logRecord.dstport);

--- a/index.js
+++ b/index.js
@@ -154,7 +154,7 @@ function postDocumentToES(doc, context) {
   var req = new AWS.HttpRequest(endpoint);
 
   req.method = "POST";
-  req.path = path.join("/", index, logType);
+  req.path = path.join("/", index, "_doc");
   req.region = region;
   req.body = doc;
   req.headers["presigned-expires"] = false;


### PR DESCRIPTION
need `_doc` instead of logType to have logs correctly ingested by OpenSearch

need `request_creation_time` field has an additional time field has it's the current in use `timeFieldName` in the index pattern